### PR TITLE
Add dataset instructions

### DIFF
--- a/DATASET.md
+++ b/DATASET.md
@@ -1,0 +1,25 @@
+# Dataset
+
+This project relies on an image-to-code dataset hosted on [HuggingFace](https://huggingface.co/datasets/lyleokoth/image-to-code-v1). Each entry provides a rendered image and the corresponding CadQuery code.
+
+## Download
+
+Use the helper script to fetch a small subset for local experiments:
+
+```bash
+python scripts/download_hf_dataset.py
+```
+
+The script streams the dataset and creates a `data` directory with the following layout:
+
+```
+data/
+├── train/       # training images
+├── test/        # testing images
+├── train.jsonl  # metadata mapping image paths to CadQuery code
+└── test.jsonl
+```
+
+`train.jsonl` and `test.jsonl` contain one JSON object per line with `image_path` and `code` fields.
+
+Other training or evaluation scripts should load images and code from these files and directories.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@
 ## Report Structure
 - Provide an overview of how to present findings and conclusions.
 
+## Dataset
+See [DATASET.md](DATASET.md) for instructions on downloading a small subset of
+the image-to-code dataset from HuggingFace using the provided helper script.
+


### PR DESCRIPTION
## Summary
- explain how to fetch the dataset from HF
- document helper script usage and output layout
- link dataset instructions from README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68624d9e94c483339b38a2d48b540cc8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new DATASET.md file detailing the image-to-code dataset and instructions for downloading and organizing it.
  * Updated the README with a "Dataset" section that links to the new DATASET.md for further guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->