### PR TITLE
Add critical path scheduling service

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,20 @@ For an interactive walkthrough, see Owein's `good_luck.ipynb`.
 
 See [COMPARISON.md](COMPARISON.md) for detailed analysis of different training approaches and their implications.
 
+## API Server
+
+This repository now includes a small FastAPI application (`server.py`) that exposes
+an endpoint for retrieving the critical path of a project.
+
+Run the server:
+
+```bash
+uvicorn server:app --reload
+```
+
+Retrieve a project's critical path:
+
+```bash
+curl http://localhost:8000/projects/1/critical-path
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,6 @@ dependencies = [
     "torch>=2.5.1",
     "transformers>=4.52.4",
     "pillow>=10.0.0",
+    "fastapi>=0.110.0",
+    "uvicorn>=0.29.0",
 ]

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+@dataclass
+class Task:
+    id: str
+    duration: int
+    dependencies: List[str] = field(default_factory=list)
+    ES: int = 0  # Early start
+    EF: int = 0  # Early finish
+    LS: int = 0  # Late start
+    LF: int = 0  # Late finish
+    total_float: int = 0
+
+
+def forward_pass(tasks: Dict[str, 'Task']):
+    for task in tasks.values():
+        if task.dependencies:
+            task.ES = max(tasks[dep].EF for dep in task.dependencies)
+        else:
+            task.ES = 0
+        task.EF = task.ES + task.duration
+
+
+def backward_pass(tasks: Dict[str, 'Task']):
+    max_finish = max(task.EF for task in tasks.values())
+    # Start from tasks sorted in reverse of EF
+    for task in sorted(tasks.values(), key=lambda t: t.EF, reverse=True):
+        if not any(task.id in tasks[d].dependencies for d in tasks):
+            task.LF = max_finish
+        else:
+            successors = [t for t in tasks.values() if task.id in t.dependencies]
+            task.LF = min(s.LS for s in successors)
+        task.LS = task.LF - task.duration
+        task.total_float = task.LF - task.EF
+
+
+def critical_path(tasks: Dict[str, 'Task']):
+    return [t.id for t in tasks.values() if t.total_float == 0]

--- a/server.py
+++ b/server.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI, HTTPException
+from typing import Dict
+from scheduler import Task, forward_pass, backward_pass, critical_path
+
+app = FastAPI(title="Project Scheduler")
+
+# Example in-memory projects
+data: Dict[str, Dict[str, Task]] = {
+    "1": {
+        "A": Task(id="A", duration=3),
+        "B": Task(id="B", duration=2, dependencies=["A"]),
+        "C": Task(id="C", duration=4, dependencies=["A"]),
+        "D": Task(id="D", duration=2, dependencies=["B", "C"]),
+    }
+}
+
+@app.get("/projects/{project_id}/critical-path")
+def get_critical_path(project_id: str):
+    if project_id not in data:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    tasks = data[project_id]
+    forward_pass(tasks)
+    backward_pass(tasks)
+    path = critical_path(tasks)
+    return {
+        "critical_path": path,
+        "tasks": {
+            t.id: {
+                "ES": t.ES,
+                "EF": t.EF,
+                "LS": t.LS,
+                "LF": t.LF,
+                "total_float": t.total_float,
+            }
+            for t in tasks.values()
+        },
+    }

--- a/test_scheduler.py
+++ b/test_scheduler.py
@@ -1,0 +1,18 @@
+from scheduler import Task, forward_pass, backward_pass, critical_path
+
+tasks = {
+    'A': Task(id='A', duration=3),
+    'B': Task(id='B', duration=2, dependencies=['A']),
+    'C': Task(id='C', duration=4, dependencies=['A']),
+    'D': Task(id='D', duration=2, dependencies=['B', 'C']),
+}
+
+forward_pass(tasks)
+backward_pass(tasks)
+path = critical_path(tasks)
+
+
+def test_forward_backward_pass():
+    assert tasks['A'].ES == 0 and tasks['A'].EF == 3
+    assert tasks['D'].LF == tasks['D'].EF
+    assert path == ['A', 'C', 'D']


### PR DESCRIPTION
## Summary
- implement scheduler with backward pass for LS/LF and total float
- expose `/projects/{id}/critical-path` via FastAPI
- document usage in README
- include simple unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ef11969883339f770956fb437fb7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API server that provides an endpoint to retrieve the critical path and scheduling metrics for a project.
* **Documentation**
  * Updated the README with instructions for running the API server and accessing the critical path endpoint.
* **Chores**
  * Added FastAPI and Uvicorn as project dependencies.
* **Tests**
  * Introduced tests to verify critical path calculations and scheduling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->